### PR TITLE
Upsert on table to respect omit tags

### DIFF
--- a/src/postgraphile-upsert.ts
+++ b/src/postgraphile-upsert.ts
@@ -17,6 +17,7 @@ const PgMutationUpsertPlugin: Plugin = builder => {
         GraphQLString
       },
       inflection,
+      pgOmit: omit,
       newWithHooks,
       parseResolveInfo,
       pgGetGqlInputTypeByTypeIdAndModifier,
@@ -36,6 +37,7 @@ const PgMutationUpsertPlugin: Plugin = builder => {
       fields,
       pgIntrospectionResultsByKind.class
         .filter((table: any) => !!table.namespace)
+        .filter((table: any) => !omit(table, 'upsert'))
         .filter((table: any) => table.isSelectable)
         .filter((table: any) => table.isInsertable)
         .filter((table: any) => table.isUpdatable)


### PR DESCRIPTION
Upsert should be ommitted if "@omit" tag is present

Works for both:

```COMMENT ON TABLE table_name IS '@omit upsert';```
(- omit ```upsert``` query only, other operations to be untouched)

and:

```COMMENT ON TABLE table_name IS '@omit';```
(- omit all queries on ```table_name```)