### PR TITLE
feat: skip table types that do not have primary key constraints

### DIFF
--- a/src/postgraphile-upsert.ts
+++ b/src/postgraphile-upsert.ts
@@ -32,6 +32,7 @@ export const PgMutationUpsertPlugin: Plugin = (builder) => {
       fields,
       pgIntrospectionResultsByKind.class
         .filter((table: any) => !!table.namespace)
+        .filter((table: any) => !!table.primaryKeyConstraint)
         .filter((table: any) => !omit(table, "upsert"))
         .filter((table: any) => table.isSelectable)
         .filter((table: any) => table.isInsertable)


### PR DESCRIPTION
This PR adds a filter to the upsertable types that ensures the table has a `primaryKeyConstraint` before attempting to create the upsert mutation/types.

This PR resolves https://github.com/cdaringe/postgraphile-upsert/issues/214 .