### PR TITLE
feat: allow omitting defaulted columns

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -173,6 +173,23 @@ const fetchAllRoles = async (t: PluginExecutionContext) => {
   return execGqlOp(t, query);
 };
 
+const fetchAllCars = async (t: PluginExecutionContext) => {
+  const query = nanographql`
+  query {
+    allCars {
+      edges {
+        node {
+          make
+          model
+          trim
+          active
+        }
+      }
+    }
+  }`;
+  return execGqlOp(t, query);
+};
+
 const create = async (
   t: PluginExecutionContext,
   extraProperties: Record<string, unknown> = {}
@@ -388,5 +405,66 @@ test("upsert where clause", async (t) => {
 
     // assert only one record
     t.is(res.data.allRoles.edges.length, 1);
+  }
+});
+
+test("upsert handling of nullable defaulted columns", async (t) => {
+  await t.context.client.query(`
+      create table car(
+        id serial primary key,
+        make text not null,
+        model text not null,
+        trim text not null default 'standard',
+        active boolean,
+        unique (make, model, trim)
+      )
+  `);
+  await initializePostgraphile(t);
+  const upsertCar = async ({
+    trim,
+    active = false,
+  }: {
+    trim?: string;
+    make?: string;
+    model?: string;
+    active?: boolean;
+  } = {}) => {
+    const query = nanographql(`
+      mutation {
+        upsertCar(where: {
+          make: "Honda",
+          model: "Civic",
+        },
+        input: {
+          car: {
+            make: "Honda",
+            model: "Civic",
+            ${trim ? `trim: "${trim}"` : ""}
+            active: ${active}
+          }
+        }) {
+          clientMutationId
+        }
+      }
+    `);
+    return execGqlOp(t, query);
+  };
+  {
+    await upsertCar();
+    await upsertCar({ active: true });
+    let res = await fetchAllCars(t);
+    t.is(res.data.allCars.edges.length, 1);
+    t.like(res.data.allCars.edges[0], {
+      node: {
+        active: true,
+        make: "Honda",
+        model: "Civic",
+        trim: "standard",
+      },
+    });
+
+    await upsertCar({ trim: "non-standard" });
+    res = await fetchAllCars(t);
+    t.is(res.data.allCars.edges.length, 2);
   }
 });

--- a/src/postgraphile-upsert.ts
+++ b/src/postgraphile-upsert.ts
@@ -448,6 +448,7 @@ function createUpsertField({
       {
         pgFieldIntrospection: table,
         isPgCreateMutationField: false,
+        isPgUpsertMutationField: true,
       }
     ),
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type Tags = unknown;
 export interface KeyAttribute {
   $ref: string;
+  name: string;
 }
 export interface Constraint {
   kind: string;


### PR DESCRIPTION
## The problem/concern

Postgres upsert constraints occur after the row is fully constructed, which allows postgres to set columns that have defaults and for pre-insert triggers to execute, before checking against the upsert constraint to determine how to handle the record.

Currently, the upsert logic flow we have in this plugin attempts to determine which constraint to use following a decision flow of:

1. First, find a constraint that matches fields indicated in the `where` clause (we've discussed how technically this parameter isn't really necessary, but will remain for now)
2. Next, find a constraint based on the input data (i.e. the fields being set in the payload)
3. Finally, default to using the primary constraint of the table (acts as a standard insert mutation for serial keys, etc)

If a schema has a defaulted column that is _also_ used within a constraint, the client shouldn't have to know about/pass that column if they desire is to use the default value; however, the current logic will now select the correct constraint and return an error.

## The proposed solution

Update our logic to add an additional step between (2) and (3) above, where we check for a constraint that contains the input fields passed up _plus_ any columns that have defaults in the database. If we find a match, use this constraint for the upsert operation.

There is a test that exemplifies what this PR is trying to solve. See [L417](https://github.com/mgagliardo91/postgraphile-upsert/blob/a96ff52569d3205517b901b230c2fc4156b74490/src/__tests__/main.test.ts#L417).

Once again, thanks for maintaining this repo @cdaringe - its getting more actively used on our end now, so hopefully you don't mind the additional requests that will help move us forward.