### PR TITLE
feat: support upserting tables with only unique constraint(s)

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -235,7 +235,7 @@ test("ignores tables without primary keys or unique constraints", async (t) => {
       .map(({ name }) => name)
       .filter((name) => name.startsWith("upsert"))
   );
-  t.assert(upsertMutations.size === 2);
+  t.assert(upsertMutations.size === 3);
   t.assert(upsertMutations.has("upsertBike"));
   t.assert(upsertMutations.has("upsertRole"));
   t.assert(upsertMutations.has("upsertJustUniqueConstraint"));

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -84,7 +84,7 @@ test.beforeEach(async (t) => {
   await t.context.client.query(`
     create table just_unique_constraints (
       name text,
-      unique (text)
+      unique (name)
     )
   `);
   await initializePostgraphile(t);

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -81,6 +81,12 @@ test.beforeEach(async (t) => {
         name text
       )
   `);
+  await t.context.client.query(`
+    create table just_unique_constraints (
+      name text,
+      unique (text)
+    )
+  `);
   await initializePostgraphile(t);
 });
 
@@ -221,7 +227,7 @@ const create = async (
   return execGqlOp(t, nanographql(mutation));
 };
 
-test("ignores tables without primary keys", async (t) => {
+test("ignores tables without primary keys or unique constraints", async (t) => {
   await create(t);
   const res = await fetchMutationTypes(t);
   const upsertMutations = new Set(
@@ -232,6 +238,7 @@ test("ignores tables without primary keys", async (t) => {
   t.assert(upsertMutations.size === 2);
   t.assert(upsertMutations.has("upsertBike"));
   t.assert(upsertMutations.has("upsertRole"));
+  t.assert(upsertMutations.has("upsertJustUniqueConstraint"));
 });
 
 test("upsert crud - match primary key constraint", async (t) => {


### PR DESCRIPTION
# Problem

Upsert mutations are not created for tables without primary keys, even if they have at least one unique constraint. This is inconsistent with Postgraphile core, which generates update mutations for tables with just unique constraints.

# Proposed Solution

This updates logic to check for primary key OR at least one unique constraint on the table.

# Testing

I have extended an existing test case but have not run the test suite yet (a Contributing section in readme would be a nice addition 🙂).

I have verified behavior experimentally by `yarn link`ing the local clone to an application codebase.